### PR TITLE
Add Finite.dinduction_on'

### DIFF
--- a/Mathlib/Data/Set/Finite.lean
+++ b/Mathlib/Data/Set/Finite.lean
@@ -1171,6 +1171,15 @@ theorem Finite.dinduction_on {C : ∀ s : Set α, s.Finite → Prop} (s : Set α
   this h
 #align set.finite.dinduction_on Set.Finite.dinduction_on
 
+@[elab_as_elim]
+theorem Finite.dinduction_on' {C : ∀ s : Set α, s.Finite → Prop}
+    (H0 : C ∅ finite_empty)
+    (H1 : ∀ {a s}, a ∉ s → ∀ h : Set.Finite s, C s h → C (insert a s) (h.insert a))  {s : Set α} (h : s.Finite) : C s h :=
+  have : ∀ h : s.Finite, C s h :=
+    Finite.induction_on h (fun _ => H0) fun has hs ih _ => H1 has hs (ih _)
+  this h
+
+
 section
 
 attribute [local instance] Nat.fintypeIio


### PR DESCRIPTION
As is shown in [this zulip discussion](https://leanprover.zulipchat.com/#narrow/stream/287929-mathlib4/topic/tactic.20to.20apply.20induction.20on.20finite.20sets), this theorem may be useful to prove properties of finite sets.


---
<!-- The text above the `---` will become the commit message when your
PR is merged. Please leave a blank newline before the `---`, otherwise
GitHub will format the text above it as a title.

To indicate co-authors, include lines at the bottom of the commit message
(that is, before the `---`) using the following format:

Co-authored-by: Author Name <author@email.com>

Any other comments you want to keep out of the PR commit should go
below the `---`, and placed outside this HTML comment, or else they
will be invisible to reviewers.

If this PR depends on other PRs, please list them below this comment,
using the following format:
- [ ] depends on: #abc [optional extra text]
- [ ] depends on: #xyz [optional extra text]
-->

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
